### PR TITLE
Update README.md to proper Google Colab link

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ notebook, where researchers can query one of our trained models to get text
 restorations, visualise attention weights, and more.
 
 -   [Aeneas Interactive Interface](https://predictingthepast.com/)
--   [Google Colab for using Aeneas for your research](https://colab.research.google.com/github/deepmind/predictingthepast/blob/master/colabs/predictingthepast_inference.ipynb)
+-   [Google Colab for using Aeneas for your research](https://colab.sandbox.google.com/github/google-deepmind/predictingthepast/blob/main/colabs/inference.ipynb)
 
 ## Aeneas Inference Offline
 


### PR DESCRIPTION
The previous README contained an outdated link, preventing easy access to the colab document to use Aeneas. Recommended fix for issue #3 .